### PR TITLE
Bump version to 2024.10.1b1 pre-release

### DIFF
--- a/jax_ai_stack/__init__.py
+++ b/jax_ai_stack/__init__.py
@@ -1,3 +1,3 @@
 """jax-ai-stack metapackage."""
 
-__version__ = "0.0.0"  # keep in sync with pyproject.toml
+__version__ = "2024.10.1b1"  # keep in sync with pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jax-ai-stack"
-version = "0.0.0"  # keep in sync with jax_ai_stack/__init__.py
+version = "2024.10.1b1"  # keep in sync with jax_ai_stack/__init__.py
 description = ""
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
We'll use this release tag to test the new PyPI deployment before the real release tomorrow.