### PR TITLE
readthedocs: enable fail on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
    install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ source_suffix = ['.rst', '.ipynb', '.md']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'alabaster'
-html_static_path = ['_static']
+html_static_path = []
 
 exclude_patterns = [
     # Sometimes sphinx reads its own outputs as inputs!


### PR DESCRIPTION
Notebook execution failures are surfaced as build warnings; we need to fail the build when encountering such a warning.