### PR TITLE
DOC - Update contribution guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,20 @@
-*.egg-info
-Pipfile
+# Distribution / packaging
+.Python
 build/
 dist/
+*.egg-info/
+*.egg
+MANIFEST
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pipenv
+Pipfile.lock
+Pipfile
+
+# cache
+__pycache__/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,33 +1,56 @@
 # Developer docs
 
-## Contributing to JAX AI Stack Documentation
+## Contributing to the JAX AI Stack Documentation
+
 The documentation in the `jax-ai-stack` repository is meant to build on documentation
 of individual packages, and specifically cover topics that touch on multiple packages
 in the stack. If you see something missing and would like to contribute, please first
 [open an issue](https://github.com/jax-ml/jax-ai-stack/issues/new) and let us know what
 you have in mind!
 
+## Pre-requisites
+
+To contribute to the documentation, you will need to set your development environment.
+
+You can create a virtual environment and install the dependencies with the following commands:
+
+```bash
+virtualenv jax-docs
+# activate the virtual environment
+source jax-docs/bin/activate
+# install the dependencies
+python -m pip install -r docs/requirements.txt
+```
+
 ## Documentation via Jupyter notebooks
-The jax-ai-stack documentation includes a number of Jupyter notebooks which are rendered
+
+The `jax-ai-stack` documentation includes Jupyter notebooks that are rendered
 directly into the website via the [myst-nb](https://myst-nb.readthedocs.io/) extension.
-In order to ease review and diff of notebooks, we keep markdown versions of the content
+To ease review and diff of notebooks, we keep markdown versions of the content
 synced via [jupytext](https://jupytext.readthedocs.io/).
 
 ### Adding a new notebook
+
+We aim to have one notebook per topic or tutorial covered.
 To add a new notebook to the repository, first move the notebook into the appropriate
-location in the `docs` directory. For example, you could do something like this:
+location in the `docs` directory:
+
+```bash
+mv ~/new-tutorial.ipynb jax-ai-stack/docs/new_tutorial.ipynb
 ```
-mv ~/new-tutorial.ipynb docs/new_tutorial.ipynb
-```
-Next, we use jupytext to mark the notebook for syncing with markdown:
-```
-pip install jupytext
+
+Next, we use `jupytext` to mark the notebook for syncing with Markdown:
+
+```bash
 jupytext --set-formats ipynb,md:myst docs/new_tutorial.ipynb
 ```
+
 Finally, we can sync the notebook and markdown source:
-```
+
+```bash
 jupytext --sync docs/new_tutorial.ipynb
 ```
+
 To ensure that the new notebook is rendered as part of the site, be sure to add
 references to a `toctree` declaration somewhere in the source tree, for example
 in `docs/tutorials.md`. You will also need to add references in `docs/conf.py`
@@ -35,15 +58,28 @@ to specify whether the notebook should be executed, and to specify which file
 sphinx should use when generating the site.
 
 ### Editing an existing notebook
-When editing the text of an existing notebook, it is recommended to edit just
-the markdown file, and then automatically sync using `jupytext` via the
-`pre-commit` framework, which we use to check in github CI that notebooks are
-properly synced. For example, say you have edited `docs/new_tutorial.md`, then
+
+When editing the text of an existing notebook, it is recommended to edit the
+markdown file only, and then automatically sync using `jupytext` via the
+`pre-commit` framework, which we use to check in GitHub CI that notebooks are
+properly synced.
+For example, say you have edited `docs/new_tutorial.md`, then
 you can do the following:
-```
+
+```bash
 pip install pre-commit
 git add docs/new_tutorial.*          # stage the new changes
 pre-commit run                       # run pre-commit checks on added files
 git add docs/new_tutorial.*          # stage the files updated by pre-commit
 git commit -m "update new tutorial"  # commit to the branch
 ```
+
+## Building the documentation locally
+
+To build the documentation locally, you can run the following command:
+
+```bash
+sphinx-build -b html docs/ docs/_build/html
+```
+
+You can then open the generated HTML files in your browser by opening `docs/_build/html/index.html`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,8 @@ matplotlib
 penzai
 scikit-learn
 
+# Needed to conver from Jupyter to markdown
+jupytext
+
 # install jax-ai-stack from current directory
 .


### PR DESCRIPTION
This PR follows #67 and adds some improvements

- **Add jupytext to requirements**
- **Update gitignore**
- **Update docs contribution guidelines**

Looking at https://jax.readthedocs.io/en/latest/contributing.html, it might be worth adding similar instructions to set the dev environment and install pre-commit.

Also, perhaps we should link to these new docs from the top-level CONTRIBUTING.md