### PR TITLE
DOC: Update link to Getting Started guide in index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,7 @@ single point-of-entry for this suite of libraries, so you can install and begin
 using many of the same open source packages that Google developers are using
 in their everyday work.
 
-To get started with the JAX AI stack, you can check out [Getting started with JAX](
-https://github.com/jax-ml/jax-ai-stack/blob/main/docs/getting_started_with_jax_for_AI.ipynb).
+To get started with the JAX AI stack, you can check out {doc}`getting_started_with_jax_for_AI`.
 This is still a work-in-progress, please check back for more documentation and tutorials
 in the coming weeks!
 


### PR DESCRIPTION
The current link goes to the raw ipynb file in the repo, while the new link correctly points to the html page.