### PR TITLE
Add linkify extension to automatically create links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,10 @@ suppress_warnings = [
 
 # -- Options for myst ----------------------------------------------
 myst_heading_anchors = 3  # auto-generate 3 levels of heading anchors
-myst_enable_extensions = ['dollarmath']
+myst_enable_extensions = [
+    "dollarmath",
+    "linkify",
+]
 nb_execution_mode = 'force'
 nb_execution_allow_errors = False
 nb_merge_streams = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # Sphinx-related requirements.
 sphinx
 myst-nb
+myst-parser[linkify]
 
 # Packages required for notebook execution
 matplotlib


### PR DESCRIPTION
This extension allows links to be written in plain text as

`http://jax.readthedocs.io/`

in the source md/ipynb file, but they will show up as proper links in the html file:

![Captura de imagem_20241017_172950](https://github.com/user-attachments/assets/3cbc170b-3860-42b8-9a7a-6d09902e9362)
