### PR TITLE
Change documentation theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ source_suffix = ['.rst', '.ipynb', '.md']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_book_theme'
-html_title = "JAX AI Stack"
+html_title = 'JAX AI Stack'
 html_static_path = ['']
 
 # Theme-specific options

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ release = '0.0.0'
 
 extensions = [
     'myst_nb',
+    'sphinx_copybutton',
 ]
 
 templates_path = ['_templates']
@@ -26,8 +27,20 @@ source_suffix = ['.rst', '.ipynb', '.md']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = []
+html_theme = 'sphinx_book_theme'
+html_title = "JAX AI Stack"
+html_static_path = ['']
+
+# Theme-specific options
+# https://sphinx-book-theme.readthedocs.io/en/stable/reference.html
+html_theme_options = {
+    'show_navbar_depth': 2,
+    'show_toc_level': 2,
+    'repository_url': 'https://github.com/jax-ml/jax-ai-stack',
+    'path_to_docs': 'docs/',
+    'use_repository_button': True,
+    'navigation_with_keys': True,
+}
 
 exclude_patterns = [
     # Sometimes sphinx reads its own outputs as inputs!

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,8 @@
 sphinx
 myst-nb
 myst-parser[linkify]
+sphinx-book-theme
+sphinx-copybutton
 
 # Packages required for notebook execution
 matplotlib


### PR DESCRIPTION
This PR introduces `sphinx_book_theme`, similar to the [JAX documentation](https://jax.readthedocs.io/en/latest/installation.html#). Also adds `sphinx-copybutton` extension.

Preview link: https://jax-ai-stack--101.org.readthedocs.build/en/101/

Note for reviewers: Please also try a local docs build. I was running into intermittent sphinx warnings ("file too long" and "...ipynb :document isn't included in any toctree"). I'm fairly certain those were local env/cache issues, but will be good to verify.