### PR TITLE
Update README.md to fix link to getting started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ single point-of-entry for this suite of libraries, so you can install and begin
 using many of the same open source packages that Google developers are using
 in their everyday work.
 
-To get started with the JAX AI stack, you can check out [Getting started with JAX](
-https://github.com/jax-ml/jax-ai-stack/blob/main/docs/source/getting_started.md).
+To get started with the JAX AI stack, you can check out [Getting started with JAX](https://docs.jaxstack.ai/en/latest/getting_started.html).
 This is still a work-in-progress, please check back for more documentation and tutorials
 in the coming weeks!
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ using many of the same open source packages that Google developers are using
 in their everyday work.
 
 To get started with the JAX AI stack, you can check out [Getting started with JAX](
-https://github.com/jax-ml/jax-ai-stack/blob/main/docs/source/getting_started_with_jax_for_AI.ipynb).
+https://github.com/jax-ml/jax-ai-stack/blob/main/docs/source/getting_started.md).
 This is still a work-in-progress, please check back for more documentation and tutorials
 in the coming weeks!
 


### PR DESCRIPTION
The readme had a broken link to the getting started notebook which has now been replaced by the getting started markdown page. Updated the link to reflect this change.