### PR TITLE
[doc] Fix landing page for Firefox

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -38,7 +38,7 @@ body:has(.hero) .bd-article > section > h1 {
 
     body:has(.hero) .header-article-items,
     body:has(.hero) .doc-body > section {
-        max-width: 80rem !important;
+        max-width: 80% !important;
         align-self: center;
         width: -moz-available;
         width: -webkit-fill-available;


### PR DESCRIPTION
When visiting the landing page, the JAX AI stack image size causes the "Get started" button to be obscured by the Powered by JAX image. This PR changes a CSS property to fix this.

## Before

Chrome:
<img width="1629" alt="Screenshot 2025-06-16 at 4 06 54 PM" src="https://github.com/user-attachments/assets/ab486b42-fbc6-4534-ae50-fff5045b55be" />

Firefox:

![Captura de imagem_20250616_160541](https://github.com/user-attachments/assets/8dc61bbc-7395-4aa3-83e5-14fb206eb9c1)

## After

Chrome:
<img width="1629" alt="Screenshot 2025-06-16 at 4 08 27 PM" src="https://github.com/user-attachments/assets/226df42c-3b4e-4a24-8a4a-628d1bbe9b23" />

Firefox:

![Captura de imagem_20250616_160510](https://github.com/user-attachments/assets/6da7924c-cfb9-4e56-a089-4b1661eff6ac)
