### PR TITLE
[doc] Fix docs requirements to correctly install JAX AI Stack

### DIFF
--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -10,7 +10,13 @@ you have in mind!
 
 To contribute to the documentation, you will need to set your development environment.
 
-You can create a virtual environment or conda environment and install the packages in `docs/requirements.txt`.
+You can create a virtual environment or conda environment and install the packages in `docs/requirements.txt` by running
+
+```bash
+pip install -r docs/requirements.txt
+```
+
+from the root of the repository.
 
 ## Documentation via Jupyter notebooks
 


### PR DESCRIPTION
The current requirements.txt file tries to install the JAX AI stack package from within the docs repo, which is incorrect. This PR fixes it by pointing to the parent directory instead.