### PR TITLE
pin tensorflow to nightly version

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
-          python -m pip install -U chex jax flax grain ml_dtypes optax orbax-checkpoint orbax-export tensorflow tensorflow_datasets
+          python -m pip install -U chex jax flax grain ml_dtypes optax orbax-checkpoint orbax-export tf-nightly tensorflow_datasets
       - name: Run tests
         run: |
           pytest -n auto jax_ai_stack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
 
 # TensorFlow datasets is an extra because it has a large install footprint.
 tfds = [
-    "tensorflow==2.19.0",
+    "tf-nightly",
     "tensorflow_datasets==4.9.8",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ keywords = []
 # pip dependencies of the project
 dependencies = [
     "chex==0.1.89",
-    "grain==0.2.9",
-    "jax==0.6.0",
+    "grain==0.2.10",
+    "jax==0.6.2",
     "flax==0.10.6",
     "ml_dtypes==0.5.1",
-    "optax==0.2.4",
+    "optax==0.2.5",
     "orbax-checkpoint==0.11.13",
     "orbax-export==0.0.6",
 ]
@@ -41,7 +41,7 @@ dev = [
 # TensorFlow datasets is an extra because it has a large install footprint.
 tfds = [
     "tf-nightly",
-    "tensorflow_datasets==4.9.8",
+    "tensorflow_datasets==4.9.9",
 ]
 
 # Grain is now part of the default installation; keep this for


### PR DESCRIPTION
This mainly serves as a test to confirm whether the next TF release will fix the test failures related to JAX version updates