### PR TITLE
Merge updated MiniGPT example into main.

### DIFF
--- a/docs/source/JAX_for_LLM_pretraining.ipynb
+++ b/docs/source/JAX_for_LLM_pretraining.ipynb
@@ -2,14 +2,34 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a miniGPT language model with JAX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://kaggle.com/kernels/welcome?src=https://github.com/jax-ml/jax-ai-stack/blob/main/docs/source/JAX_for_LLM_pretraining.ipynb\"><img src=\"https://www.kaggle.com/static/images/logos/kaggle-logo-transparent-300.png\" height=\"32\" width=\"70\"/>Run in Kaggle</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/jax-ml/jax-ai-stack/blob/main/docs/source/JAX_for_LLM_pretraining.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/jax-ml/jax-ai-stack/blob/main/docs/source/JAX_for_LLM_pretraining.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "NIOXoY1xgiww"
    },
    "source": [
-    "# Train a miniGPT language model with JAX\n",
-    "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jax-ml/jax-ai-stack/blob/main/docs/source/JAX_for_LLM_pretraining.ipynb)\n",
-    "\n",
     "This tutorial demonstrates how to use JAX, [Flax NNX](http://flax.readthedocs.io) and [Optax](http://optax.readthedocs.io) for language model (pre)training using data and tensor [parallelism](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization) for [Single-Program Multi-Data](https://en.wikipedia.org/wiki/Single_program,_multiple_data)). It was originally inspired by the [Keras miniGPT tutorial](https://keras.io/examples/generative/text_generation_with_miniature_gpt/).\n",
     "\n",
     "Here, you will learn how to:\n",
@@ -17,7 +37,7 @@
     "- Define the miniGPT model with Flax and JAX automatic parallelism\n",
     "- Load and preprocess the dataset\n",
     "- Create the loss and training step functions\n",
-    "- Train the model on Google Colab’s Cloud TPU v2\n",
+    "- Train the model on TPUs on Kaggle or Google Colab\n",
     "- Profile for hyperparameter tuning\n",
     "\n",
     "If you are new to JAX for AI, check out the [introductory tutorial](https://jax-ai-stack.readthedocs.io/en/latest/neural_net_basics.html), which covers neural network building with [Flax NNX](https://flax.readthedocs.io/en/latest/nnx_basics.html)."
@@ -36,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -69,7 +89,7 @@
     }
    ],
    "source": [
-    "!pip install -Uq tiktoken grain matplotlib"
+    "!pip install -Uq tiktoken jax-ai-stack[grain] matplotlib"
    ]
   },
   {
@@ -78,7 +98,7 @@
     "id": "Rcji_799n4eA"
    },
    "source": [
-    "**Note:** If you are using [Google Colab](https://colab.research.google.com/), select the free Google Cloud TPU v2 as the hardware accelerator.\n",
+    "**Note:** If you are using [Kaggle](https://www.kaggle.com/), select the free TPU v5e-8 as the hardware accelerator. If you are using [Google Colab](https://colab.research.google.com/), select the free Google Cloud TPU v5e-1 as the hardware accelerator. You may also use Google Cloud TPUs.\n",
     "\n",
     "Check the available JAX devices, or [`jax.Device`](https://jax.readthedocs.io/en/latest/_autosummary/jax.Device.html), with [`jax.devices()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.devices.html). The output of the cell below will show a list of 8 (eight) devices."
    ]
@@ -175,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "MKYFNOhdLq98"
    },
@@ -213,7 +233,9 @@
     "- Tensor parallelism allows us to split the model parameter tensors across several devices (sharding model tensors).\n",
     "- You can learn more about the basics of JAX parallelism in more detail in the [Introduction to parallel programming](https://jax.readthedocs.io/en/latest/sharded-computation.html) on the JAX documentation site.\n",
     "\n",
-    "In this example, we'll utilize a 4-way data parallel and 2-way tensor parallel setup. The free Google Cloud TPU v2 on Google Colab offers 4 chips, each with 2 TPU cores. The TPU v2 architeture aligns with the proposed setup.\n",
+    "In this example, we'll utilize a 4-way data parallel and 2-way tensor parallel setup, which is aligned with Kaggle TPU v5e-8 or newer GCP TPUs chips.\n",
+    "\n",
+    "Note that as of October 2025, free-tier Colab only offers TPU v5e-1, which can no longer support SPMD.\n",
     "\n",
     "### jax.sharding.Mesh\n",
     "\n",
@@ -223,28 +245,34 @@
     "- `devices`: This will take the value of [`jax.experimental.mesh_utils((4, 2))`](https://jax.readthedocs.io/en/latest/jax.experimental.mesh_utils.html), enabling us to build a device mesh. It is a NumPy ndarray with JAX devices (a list of devices from the JAX backend as obtained from [`jax.devices()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.devices.html#jax.devices))..\n",
     "- `axis_names`, where:\n",
     "  - `batch`: 4 devices along the first axis - i.e. sharded into 4 - for data parallelism; and\n",
-    "  - `model`: 2 devices along the second axis - i.e. sharded into 2 -  for tensor paralleism, mapping to the TPU v2 cores.\n",
+    "  - `model`: 2 devices along the second axis - i.e. sharded into 2 -  for tensor parallism\n",
     "\n",
-    "This matches the `(4, 2)` structure in the Colab's TPU v2 setup.\n",
+    "This matches the structure in the Kaggle TPU v5e setup.\n",
     "\n",
     "Let's instantiate `Mesh` as `mesh` and declare the TPU configuration to define how data and model parameters are distributed across the devices:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "id": "xuMlCK3Q8WJD"
    },
    "outputs": [],
    "source": [
     "# Create a `Mesh` object representing TPU device arrangement.\n",
-    "mesh = Mesh(mesh_utils.create_device_mesh((4, 2)), ('batch', 'model'))\n",
+    "# For example, for Kaggle TPU v5e-8:\n",
+    "if jax.device_count() == 8:\n",
+    "    mesh = Mesh(mesh_utils.create_device_mesh((4, 2)), ('batch', 'model'))\n",
     "\n",
-    "### Alternatively, we could use the 8-way data parallelism with only one line of code change.\n",
-    "### JAX enables quick experimentation with different partitioning strategies\n",
-    "### like this. We will come back to this point at the end of this tutorial.\n",
-    "# mesh = Mesh(mesh_utils.create_device_mesh((8, 1)), ('batch', 'model'))"
+    "    ### Alternatively, we could use the 8-way data parallelism with only one line of code change.\n",
+    "    ### JAX enables quick experimentation with different partitioning strategies\n",
+    "    ### like this. We will come back to this point at the end of this tutorial.\n",
+    "    # mesh = Mesh(mesh_utils.create_device_mesh((8, 1)), ('batch', 'model'))\n",
+    "\n",
+    "### For free-tier Colab TPU, which only has a single TPU core\n",
+    "if jax.device_count() == 1:\n",
+    "    mesh = Mesh(mesh_utils.create_device_mesh((1, 1)), (\"batch\", \"model\"))"
    ]
   },
   {
@@ -285,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "z0p-IHurrB9i"
    },
@@ -446,48 +474,31 @@
     "        outputs = self.output_layer(x)\n",
     "        return outputs\n",
     "\n",
-    "    # Text generation.\n",
-    "    def generate_text(self, max_tokens: int, start_tokens: [int], top_k=10):\n",
-    "        # Sample the next token from a probability distribution based on\n",
-    "        # `logits` and `tok_k` (top-k) sampling strategy.\n",
-    "        def sample_from(logits):\n",
-    "            logits, indices = jax.lax.top_k(logits, k=top_k)\n",
-    "            # Convert logits to probabilities (using `flax.nnx.softmax`).\n",
-    "            logits = nnx.softmax(logits)\n",
-    "            return jax.random.choice(jax.random.PRNGKey(0), indices, p=logits)\n",
+    "    @nnx.jit\n",
+    "    def sample_from(self, logits):\n",
+    "        logits, indices = jax.lax.top_k(logits, k=top_k)\n",
+    "        logits = nnx.softmax(logits)\n",
+    "        return jax.random.choice(jax.random.PRNGKey(0), indices, p=logits)\n",
     "\n",
-    "        # Generate text one token at a time until the maximum token limit is reached (`maxlen`).\n",
-    "        def generate_step(start_tokens):\n",
-    "            pad_len = maxlen - len(start_tokens)\n",
-    "            # Index of the last token in the current sequence.\n",
-    "            sample_index = len(start_tokens) - 1\n",
-    "            # If the input is longer than `maxlen`, then truncate it.\n",
-    "            if pad_len < 0:\n",
-    "                x = jnp.array(start_tokens[:maxlen])\n",
-    "                sample_index = maxlen - 1\n",
-    "            # If the input is shorter than `maxlen`, then pad it (`pad_len`).\n",
-    "            elif pad_len > 0:\n",
-    "                x = jnp.array(start_tokens + [0] * pad_len)\n",
-    "            else:\n",
-    "                x = jnp.array(start_tokens)\n",
+    "    @nnx.jit\n",
+    "    def generate_step(self, padded_tokens, sample_index):\n",
+    "        logits = self(padded_tokens)\n",
+    "        next_token = self.sample_from(logits[0][sample_index])\n",
+    "        return next_token\n",
     "\n",
-    "            # Add a batch dimension.\n",
-    "            x = x[None, :]\n",
-    "            logits = self(x)\n",
-    "            next_token = sample_from(logits[0][sample_index])\n",
-    "            return next_token\n",
-    "\n",
-    "        # Store generated tokens.\n",
+    "    def generate_text(self, max_tokens, start_tokens):\n",
     "        generated = []\n",
-    "        # Generate tokens until the end-of-text token is encountered or the maximum token limit is reached.\n",
-    "        for _ in range(max_tokens):\n",
-    "            next_token = generate_step(start_tokens + generated)\n",
-    "            # Truncate whatever is after '<|endoftext|>' (stop word)\n",
+    "        print(tokenizer.decode(start_tokens), flush=True, end='')\n",
+    "        for i in range(max_tokens):\n",
+    "            sample_index = len(start_tokens) + len(generated) - 1\n",
+    "\n",
+    "            padded_tokens = jnp.array((start_tokens + generated + [0] * (maxlen - len(start_tokens) - len(generated))))[None, :]\n",
+    "            next_token = int(self.generate_step(padded_tokens, sample_index))\n",
     "            if next_token == tokenizer.encode('<|endoftext|>', allowed_special={'<|endoftext|>'})[0]:\n",
-    "              # Stop text generation if the end-of-text token is encountered.\n",
     "              break\n",
-    "            generated.append(int(next_token))\n",
-    "        # Decode the generated token IDs into text.\n",
+    "            generated.append(next_token)\n",
+    "            # decode and print next_token\n",
+    "            print(tokenizer.decode([next_token]), flush=True, end='')\n",
     "        return tokenizer.decode(start_tokens + generated)\n",
     "\n",
     "# Creates the miniGPT model with 4 transformer blocks.\n",
@@ -506,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "GRhiDsCrMZRp"
    },
@@ -518,8 +529,11 @@
     "embed_dim = 256\n",
     "num_heads = 8\n",
     "feed_forward_dim = 256\n",
-    "batch_size = 256 # You can set a bigger batch size if you use Kaggle's Cloud TPU.\n",
-    "num_epochs = 1"
+    "batch_size = 144 * jax.device_count() / 2  # divide by 2 in case of model parallelism\n",
+    "if jax.device_count() == 1:\n",
+    "    batch_size = 144\n",
+    "num_epochs = 1\n",
+    "top_k = 10"
    ]
   },
   {
@@ -595,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "id": "8rRuTmABNV4b"
    },
@@ -613,7 +627,7 @@
     "    grad_fn = nnx.value_and_grad(loss_fn, has_aux=True)\n",
     "    (loss, logits), grads = grad_fn(model, batch)\n",
     "    metrics.update(loss=loss, logits=logits, lables=batch[1])\n",
-    "    optimizer.update(grads)"
+    "    optimizer.update(model, grads)"
    ]
   },
   {
@@ -633,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -978,56 +992,61 @@
    ],
    "source": [
     "model = create_model(rngs=nnx.Rngs(0))\n",
-    "optimizer = nnx.ModelAndOptimizer(model, optax.adam(1e-3))\n",
+    "optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)\n",
     "metrics = nnx.MultiMetric(\n",
-    "  loss=nnx.metrics.Average('loss'),\n",
+    "    loss=nnx.metrics.Average(\"loss\"),\n",
     ")\n",
     "rng = jax.random.PRNGKey(0)\n",
     "\n",
     "start_prompt = \"Once upon a time\"\n",
     "start_tokens = tokenizer.encode(start_prompt)[:maxlen]\n",
-    "generated_text = model.generate_text(\n",
-    "    maxlen, start_tokens\n",
-    ")\n",
-    "print(f\"Initial generated text:\\n{generated_text}\\n\")\n",
-    "\n",
+    "print(\"Initial generated text:\")\n",
+    "generated_text = model.generate_text(maxlen, start_tokens)\n",
     "\n",
     "metrics_history = {\n",
-    "  'train_loss': [],\n",
+    "    \"train_loss\": [],\n",
     "}\n",
     "\n",
-    "prep_target_batch = jax.vmap(lambda tokens: jnp.concatenate((tokens[1:], jnp.array([0]))))\n",
+    "prep_target_batch = jax.vmap(\n",
+    "    lambda tokens: jnp.concatenate((tokens[1:], jnp.array([0])))\n",
+    ")\n",
     "\n",
     "step = 0\n",
     "for epoch in range(num_epochs):\n",
     "    start_time = time.time()\n",
     "    for batch in text_dl:\n",
     "        if len(batch) % len(jax.devices()) != 0:\n",
-    "          continue  # skip the remaining elements\n",
+    "            continue  # skip the remaining elements\n",
     "        input_batch = jnp.array(jnp.array(batch).T)\n",
     "        target_batch = prep_target_batch(input_batch)\n",
-    "        train_step(model, optimizer, metrics, jax.device_put((input_batch, target_batch), NamedSharding(mesh, P('batch', None))))\n",
+    "        train_step(\n",
+    "            model,\n",
+    "            optimizer,\n",
+    "            metrics,\n",
+    "            jax.device_put(\n",
+    "                (input_batch, target_batch), NamedSharding(mesh, P(\"batch\", None))\n",
+    "            ),\n",
+    "        )\n",
     "\n",
     "        if (step + 1) % 200 == 0:\n",
-    "          for metric, value in metrics.compute().items():\n",
-    "              metrics_history[f'train_{metric}'].append(value)\n",
-    "          metrics.reset()\n",
+    "            for metric, value in metrics.compute().items():\n",
+    "                metrics_history[f\"train_{metric}\"].append(value)\n",
+    "            metrics.reset()\n",
     "\n",
-    "          elapsed_time = time.time() - start_time\n",
-    "          print(f\"Step {step + 1}, Loss: {metrics_history['train_loss'][-1]}, Elapsed Time: {elapsed_time:.2f} seconds\")\n",
-    "          start_time = time.time()\n",
+    "            elapsed_time = time.time() - start_time\n",
+    "            print(\n",
+    "                f\"\\n\\nStep {step + 1}, Loss: {metrics_history['train_loss'][-1]}, Elapsed Time: {elapsed_time:.2f} seconds\"\n",
+    "            )\n",
+    "            start_time = time.time()\n",
     "\n",
-    "          generated_text = model.generate_text(\n",
-    "              maxlen, start_tokens\n",
-    "          )\n",
-    "          print(f\"Generated text:\\n{generated_text}\\n\")\n",
+    "            print(\"Generated text:\")\n",
+    "            generated_text = model.generate_text(maxlen, start_tokens)\n",
+    "\n",
     "        step += 1\n",
     "\n",
     "# Final text generation\n",
-    "generated_text = model.generate_text(\n",
-    "    maxlen, start_tokens\n",
-    ")\n",
-    "print(f\"Final generated text:\\n{generated_text}\")"
+    "print(\"Final generated text:\")\n",
+    "generated_text = model.generate_text(maxlen, start_tokens)"
    ]
   },
   {
@@ -1093,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1116,7 +1135,7 @@
     "state = nnx.state(model)\n",
     "\n",
     "checkpointer = orbax.PyTreeCheckpointer()\n",
-    "checkpointer.save('/content/save', state)\n",
+    "checkpointer.save('/content/save', args=orbax.args.PyTreeSave(state), force=True)\n",
     "\n",
     "# Make sure the files are there\n",
     "!ls /content/save/"
@@ -1127,7 +1146,9 @@
    "id": "3813cbf2",
    "metadata": {},
    "source": [
-    "## Profiling for hyperparameter tuning"
+    "## Profiling for hyperparameter tuning\n",
+    "\n",
+    "**Note:** this section assume multiple TPU cores. Free-tier Colab TPU v5e-1 cannot run here."
    ]
   },
   {


### PR DESCRIPTION
This updates the MiniGPT example in the `main` branch for the most recent Flax APIs, and points to Kaggle instead of Colab for sharded models since free Colab now has only a single TPU device. (@windmaple's work on the revamp-2025 branch)