### PR TITLE
Add blog entry for training GPT2 model with JAX

### DIFF
--- a/docs/source/blog.md
+++ b/docs/source/blog.md
@@ -3,5 +3,6 @@
 - [AI Innovators: How JAX on TPU is helping Escalante advance AI-driven protein design](https://cloud.google.com/blog/topics/customers/escalante-uses-jax-on-tpus-for-ai-driven-protein-design) - September 23, 2025 by Srikanth Kilaru
 - [Beyond backpropagation: JAX's symbolic power unlocks new frontiers in scientific computing](https://developers.googleblog.com/en/jax-symbolic-power-unlocks-new-frontiers-in-scientific-computing/) - September 9, 2025 by Srikanth Kilaru, Zekun Shi, Min Lin
 - [An efficient path to production AI: Kakao’s journey with JAX and Cloud TPUs](https://cloud.google.com/blog/products/infrastructure-modernization/kakaos-journey-with-jax-and-cloud-tpus) - August 19, 2025 by Minho Ryu, Nayeon Kim, Srikanth Kilaru
+- [Train a GPT2 model with JAX on TPU for free](https://developers.googleblog.com/en/train-gpt2-model-with-jax-on-tpu/) - Augest 12, 2025 by Wei Wei
 - [A roboticist's journey with JAX: Finding efficiency in optimal control and simulation](https://developers.googleblog.com/en/a-roboticists-journey-with-jax/) - July 29, 2025 by Srikanth Kilaru, Max Muchen Sun
 - [Stanford’s Marin foundation model: The first fully open model developed using JAX](https://developers.googleblog.com/en/stanfords-marin-foundation-model-first-fully-open-model-developed-using-jax/) - July 16, 2025 by Srikanth Kilaru, David Hall


### PR DESCRIPTION
Added a new blog entry about training a GPT2 model with JAX on TPU.